### PR TITLE
Refactoring  Runs API Module  to use PortClient to make HTTP calls

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ APPLICATION_PORT = 5000
 # ngrok free tier only allows one agent. So we tear down the tunnel on application termination
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    PortClient.authenticate(clientId=PORT_CLIENT_ID,clientSecret=PORT_CLIENT_SECRET)
+    PortClient.authenticate(clientId=PORT_CLIENT_ID, clientSecret=PORT_CLIENT_SECRET)
     logger.info("Setting up Ngrok Tunnel")
     ngrok.set_auth_token(NGROK_AUTH_TOKEN)
     ngrok.forward(

--- a/port_api_runs.py
+++ b/port_api_runs.py
@@ -1,16 +1,17 @@
 from enum import Enum
 
-import requests
 from loguru import logger
 from pydantic import AnyUrl, BaseModel
 
 from port_api_core import PortClient
 
+runs_client = PortClient(exclude_pydantic_fields="runID")
+
 API_RUNS_URL = f"{PortClient.API_BASE_URL}/actions/runs"
 API_HEADERS = PortClient.API_HEADERS
 
 
-# Base Model for all messages to include runID
+# Base Model for all bodys to include runID
 class PortActionRunBase(BaseModel):
     runID: str
 
@@ -37,42 +38,13 @@ class PortActionRunLogUpdate(PortActionRunBase):
     message: str
 
 
-def prepare_port_api_payload(message) -> str:
-    return message.model_dump_json(exclude_none=True, exclude="runID")
+def send_log_update(body: PortActionRunLogUpdate) -> str:
+    runs_client.post(url=f"{API_RUNS_URL}/{body.runID}/logs", body=body)
 
 
-# debugging sucks so hopefully this provides some context
-def log_port_api_response(raw_response: requests.models.Response):
-    if raw_response.status_code < 300:
-        logger.info("API Call Successful")
-    else:
-        logger.error(
-            f"Status Code: {raw_response.status_code} Message: {raw_response.text}"
-        )
+def send_status_update(body: PortActionActionRunUpdate) -> str:
+    runs_client.patch(url=f"{API_RUNS_URL}/{body.runID}", body=body)
 
 
-def send_log_update(message: PortActionRunLogUpdate) -> str:
-    raw_response = requests.post(
-        url=f"{API_RUNS_URL}/{message.runID}/logs",
-        headers=API_HEADERS,
-        data=prepare_port_api_payload(message),
-    )
-    log_port_api_response(raw_response)
-
-
-def send_status_update(message: PortActionActionRunUpdate) -> str:
-    raw_response = requests.patch(
-        url=f"{API_RUNS_URL}/{message.runID}",
-        headers=API_HEADERS,
-        data=prepare_port_api_payload(message),
-    )
-    log_port_api_response(raw_response)
-
-
-def send_final_update(message: PortActionActionLRunUpdateFinal) -> str:
-    raw_response = requests.patch(
-        url=f"{API_RUNS_URL}/{message.runID}",
-        headers=API_HEADERS,
-        data=prepare_port_api_payload(message),
-    )
-    log_port_api_response(raw_response)
+def send_final_update(body: PortActionActionLRunUpdateFinal) -> str:
+    runs_client.patch(url=f"{API_RUNS_URL}/{body.runID}", body=body)

--- a/port_runs_simulator.py
+++ b/port_runs_simulator.py
@@ -5,7 +5,7 @@ from faker import Faker
 
 from port_api_runs import *
 
-port_api_faker_messages = Faker()
+faker = Faker()
 
 
 def simulate_a_run(runID: str):
@@ -15,13 +15,13 @@ def simulate_a_run(runID: str):
         PortActionActionRunUpdate(
             runID=runID,
             statusLabel="INITIALIZING",
-            summary=port_api_faker_messages.paragraph(),
+            summary=faker.paragraph(),
         )
     )
     for i in range(random.randint(1, 3)):
         send_log_update(
             PortActionRunLogUpdate(
-                message=f"INITIALIZING PHASE {i}:  {port_api_faker_messages.paragraph()}",
+                message=f"INITIALIZING PHASE {i}:  {faker.paragraph()}",
                 runID=runID,
             )
         )
@@ -34,15 +34,15 @@ def simulate_a_run(runID: str):
         PortActionActionRunUpdate(
             runID=runID,
             statusLabel="PROVISIONING with Provider",
-            summary=port_api_faker_messages.paragraph(),
-            link=[port_api_faker_messages.url(), port_api_faker_messages.url()],
+            summary=faker.paragraph(),
+            link=[faker.url(), faker.url()],
         )
     )
     for i in range(random.randint(1, 3)):
         send_log_update(
             PortActionRunLogUpdate(
                 runID=runID,
-                message=f"PROVISIONING PHASE {i}:  {port_api_faker_messages.paragraph()}",
+                message=f"PROVISIONING PHASE {i}:  {faker.paragraph()}",
             )
         )
 
@@ -55,12 +55,12 @@ def simulate_a_run(runID: str):
             PortActionActionRunUpdate(
                 runID=runID,
                 statusLabel=f"UPDATES from Provider Phase {i}",
-                summary=port_api_faker_messages.paragraph(),
+                summary=faker.paragraph(),
             )
         )
         send_log_update(
             PortActionRunLogUpdate(
-                message=f"UPDATES PHASE {i}:  {port_api_faker_messages.paragraph()}",
+                message=f"UPDATES PHASE {i}:  {faker.paragraph()}",
                 runID=runID,
             )
         )
@@ -70,6 +70,6 @@ def simulate_a_run(runID: str):
         PortActionActionLRunUpdateFinal(
             runID=runID,
             status=PortActionRunFinalStatus.SUCCESS,
-            summary=port_api_faker_messages.paragraph(),
+            summary=faker.paragraph(),
         )
     )

--- a/port_runs_simulator.py
+++ b/port_runs_simulator.py
@@ -1,5 +1,7 @@
 import random
 import time
+from sys import argv
+from os import getenv
 
 from faker import Faker
 
@@ -73,3 +75,9 @@ def simulate_a_run(runID: str):
             summary=faker.paragraph(),
         )
     )
+
+if __name__ == "__main__":
+    PORT_CLIENT_ID = getenv("PORT_CLIENT_ID", "")
+    PORT_CLIENT_SECRET = getenv("PORT_CLIENT_SECRET", "")
+    PortClient.authenticate(clientId=PORT_CLIENT_ID, clientSecret=PORT_CLIENT_SECRET)
+    simulate_a_run(argv[1])


### PR DESCRIPTION
This PR removes and inverts dependencies. 

Before this PR the Runs API module did a lot of it's own HTTP / Pydantic/ Header handling

All of this has now been moved to the PortClient Class 

This makes a more reusable pattern for adding other API endpoints down the track. 

- Pydantic filtering to prepare a body for an HTTP call is now a instance method which reduces repeat code
- Non valid URLs should now be picked up by pydantic

**Drive By:** 

* Simulator module needed updating as well
* Renamed faker to be just faker rather than port_api... etc (the class is the context) 